### PR TITLE
fixed buy now button links to point to checkout_single.html

### DIFF
--- a/labs/01-basic-magecart/vulnerable-site/index.html
+++ b/labs/01-basic-magecart/vulnerable-site/index.html
@@ -51,21 +51,21 @@
           <h3>Premium Wireless Headphones</h3>
           <p class="price">$299.99</p>
           <p>Experience crystal-clear audio with our flagship headphones.</p>
-          <a href="checkout.html" class="btn">Buy Now</a>
+          <a href="checkout_single.html" class="btn">Buy Now</a>
         </div>
 
         <div class="product-card">
           <h3>Smart Watch Pro</h3>
           <p class="price">$399.99</p>
           <p>Stay connected and track your fitness goals.</p>
-          <a href="checkout.html" class="btn">Buy Now</a>
+          <a href="checkout_single.html" class="btn">Buy Now</a>
         </div>
 
         <div class="product-card">
           <h3>4K Action Camera</h3>
           <p class="price">$249.99</p>
           <p>Capture life's adventures in stunning detail.</p>
-          <a href="checkout.html" class="btn">Buy Now</a>
+          <a href="checkout_single.html" class="btn">Buy Now</a>
         </div>
       </div>
     </main>


### PR DESCRIPTION
ORIGINAL ISSUE:
Clicking "Buy Now" buttons on the product page doesn't load the checkout page in local development environment.

WHAT I EXPERIENCED:
I was going through lab 01. When I was on the product page (http://localhost:8080/) and clicked the "Buy Now" button, it redirected me to http://localhost:8080/checkout.html. However, this page only displays the filename "checkout.html" as text instead of loading the actual checkout page.

The workaround was to manually navigate to http://localhost:8080/checkout_single.html, which worked correctly.

STEPS TO REPRODUCE:
1. From `e-skimming-labs/` root directory, ran `docker-compose up -d`
2. Verified containers running with `docker-compose ps`
3. Navigated to http://localhost:9001 (Lab 1 on root setup)
4. Clicked "Buy Now" button
5. Redirected to http://localhost:9001/checkout.html
6. Page displays text "checkout_single.html" instead of loading the checkout form

WHAT I FOUND:
The "Buy Now" buttons in `index.html` had `href="checkout.html"` instead of `href="checkout_single.html"`

CHANGES MADE:
Updated all three "Buy Now" button links in `labs/01-basic-magecart/vulnerable-site/index.html` from `href="checkout.html"` to `href="checkout_single.html"`

TESTING:
Tested locally with `docker-compose up -d --build` and confirmed that clicking "Buy Now" now correctly loads the checkout page.

CONCLUSION:
The issue persists when running from project root with port 9001. The "Buy Now" buttons still point to `checkout.html` which doesn't properly load.
