### PR TITLE
Add missing ARIA Labels to Lab 1 checkout pages

### DIFF
--- a/labs/01-basic-magecart/vulnerable-site/checkout-train.html
+++ b/labs/01-basic-magecart/vulnerable-site/checkout-train.html
@@ -143,6 +143,7 @@
         <div style="float: right; margin-top: 5px">
           <a
             href="http://localhost:3000"
+            aria-label="Go back to labs"
             style="
               color: white;
               text-decoration: none;
@@ -156,6 +157,7 @@
           <a
             href="http://localhost:9002/stolen"
             target="_blank"
+            aria-label="View Stolen Data"
             style="
               color: white;
               text-decoration: none;
@@ -167,6 +169,7 @@
           >
           <a
             href="index.html"
+            aria-label="Go back to store"
             style="
               color: white;
               text-decoration: none;
@@ -201,6 +204,7 @@
             placeholder="4532 1234 5678 9012"
             maxlength="19"
             required
+            aria-label="Enter Card Number"
           />
         </div>
 
@@ -215,16 +219,17 @@
               placeholder="MM/YY"
               maxlength="5"
               required
+              aria-label="Enter Expiry date"
             />
           </div>
 
           <div class="form-group">
             <label for="cvv">CVV</label>
-            <input type="text" id="cvv" name="cvv" autocomplete="cc-csc" placeholder="123" maxlength="4" required />
+            <input type="text" id="cvv" name="cvv" autocomplete="cc-csc" placeholder="123" maxlength="4" required aria-label="Enter Cvv" />
           </div>
         </div>
 
-        <button type="submit" class="submit-btn">Complete Purchase - $299.99</button>
+        <button type="submit" class="submit-btn" aria-label="submit button to complete purchase">Complete Purchase - $299.99</button>
 
         <div class="security-badge">🔒 Your payment is secure and encrypted</div>
       </form>
@@ -243,6 +248,7 @@
         if (isLocal) {
           const clearCacheBtn = document.createElement('button')
           clearCacheBtn.textContent = '🗑️ Clear Cache'
+          clearCacheBtn.setAttribute('aria-label', 'Clear browser cache') //aria-label added
           clearCacheBtn.style.cssText = 'position:fixed;bottom:20px;right:20px;z-index:9999;padding:10px 20px;background:#dc2626;color:white;border:none;border-radius:6px;cursor:pointer;font-weight:600;box-shadow:0 4px 6px rgba(0,0,0,0.3);'
           clearCacheBtn.onclick = function() {
             if ('caches' in window) {

--- a/labs/01-basic-magecart/vulnerable-site/checkout_separate.html
+++ b/labs/01-basic-magecart/vulnerable-site/checkout_separate.html
@@ -200,6 +200,7 @@
 
       <form id="payment-form">
         <!-- Payment Information -->
+         <!--arialabel added-->
         <h3 style="margin-bottom: 1rem; color: #2c3e50">Payment Information</h3>
 
         <div class="form-group">
@@ -212,10 +213,12 @@
             placeholder="4532 1234 5678 9010"
             maxlength="19"
             required
+            aria-label="Enter Card Number"
           />
         </div>
 
         <div class="card-row">
+          <!--arialabel added-->
           <div class="form-group">
             <label for="expiry">Expiry Date</label>
             <input
@@ -226,16 +229,17 @@
               placeholder="MM/YY"
               maxlength="5"
               required
+              aria-label="Enter expiry date"
             />
           </div>
 
           <div class="form-group">
             <label for="cvv">CVV</label>
-            <input type="text" id="cvv" name="cvv" autocomplete="cc-csc" placeholder="123" maxlength="4" required />
+            <input type="text" id="cvv" name="cvv" autocomplete="cc-csc" placeholder="123" maxlength="4" required aria-label="Enter cvv code"/>
           </div>
         </div>
 
-        <button type="submit" class="submit-btn">Complete Purchase - $299.99</button>
+        <button type="submit" class="submit-btn" aria-label="Submit button to complete purchase">Complete Purchase - $299.99</button>
 
         <div class="security-badge">🔒 Your payment is secure and encrypted</div>
       </form>

--- a/labs/01-basic-magecart/vulnerable-site/checkout_single.html
+++ b/labs/01-basic-magecart/vulnerable-site/checkout_single.html
@@ -175,6 +175,8 @@
         <div style="float: right; margin-top: 5px">
           <a
             href="http://localhost:3000"
+            aria-label="Go back to labs homepage"
+            class="back-button"
             style="
               color: white;
               text-decoration: none;
@@ -183,7 +185,7 @@
               border-radius: 4px;
               margin-right: 10px;
             "
-            class="back-button"
+            
             >← Back to Labs</a
           >
           <a
@@ -198,6 +200,7 @@
               margin-right: 10px;
             "
             class="c2-button"
+            aria-label="view stolen data tab"
             >🕵️ View Stolen Data</a
           >
           <a
@@ -211,10 +214,12 @@
               border-radius: 4px;
             "
             class="writeup-button"
+            aria-label="Go to writeup section"
             >📖 Writeup</a
           >
           <a
             href="index.html"
+            aria-label="Go back to store page"
             style="
               color: white;
               text-decoration: none;
@@ -297,6 +302,7 @@
             placeholder="4532 1234 5678 9012"
             maxlength="19"
             required
+            aria-label="input card number"
           />
         </div>
 
@@ -311,16 +317,17 @@
               placeholder="MM/YY"
               maxlength="5"
               required
+              aria-label="input card expiry date"
             />
           </div>
 
           <div class="form-group">
             <label for="cvv">CVV</label>
-            <input type="text" id="cvv" name="cvv" autocomplete="cc-csc" placeholder="123" maxlength="4" required />
+            <input type="text" id="cvv" name="cvv" autocomplete="cc-csc" placeholder="123" maxlength="4" required aria-label="input cvv code"/>
           </div>
         </div>
 
-        <button type="submit" class="submit-btn">Complete Purchase - $299.99</button>
+        <button type="submit" class="submit-btn" aria-label="Completes pruchase through submit button">Complete Purchase - $299.99</button>
 
         <div class="security-badge">🔒 Your payment is secure and encrypted</div>
       </form>

--- a/labs/01-basic-magecart/vulnerable-site/index.html
+++ b/labs/01-basic-magecart/vulnerable-site/index.html
@@ -32,15 +32,15 @@
 
     <nav>
       <ul>
-        <li><a href="http://localhost:3000" class="back-button">← Back to Labs</a></li>
+        <li><a href="http://localhost:3000" class="back-button" aria-label="Go back to labs homepage">← Back to Labs</a></li>
         <li>
           <a href="http://localhost:9002/stolen" class="c2-button" target="_blank" aria-label="View Stolen Data">🕵️ View Stolen Data</a>
         </li>
         <li>
           <a href="http://localhost:3000/lab-01-writeup" class="writeup-button" target="_blank" aria-label="Lab Writeup">📖 Writeup</a>
         </li>
-        <li><a href="#">Home</a></li>
-        <li><a href="checkout.html">Checkout</a></li>
+        <li><a href="#" aria-label="Go to homepage">Home</a></li>
+        <li><a href="checkout.html" aria-label="Go to checkout page">Checkout</a></li>
       </ul>
     </nav>
 
@@ -51,21 +51,21 @@
           <h3>Premium Wireless Headphones</h3>
           <p class="price">$299.99</p>
           <p>Experience crystal-clear audio with our flagship headphones.</p>
-          <a href="checkout.html" class="btn">Buy Now</a>
+          <a href="checkout.html" class="btn" aria-label="go to Premium Wireless Headphones purchase page">Buy Now</a>
         </div>
 
         <div class="product-card">
           <h3>Smart Watch Pro</h3>
           <p class="price">$399.99</p>
           <p>Stay connected and track your fitness goals.</p>
-          <a href="checkout.html" class="btn">Buy Now</a>
+          <a href="checkout.html" class="btn" aria-label="go to Smart Watch purchase page">Buy Now</a>
         </div>
 
         <div class="product-card">
           <h3>4K Action Camera</h3>
           <p class="price">$249.99</p>
           <p>Capture life's adventures in stunning detail.</p>
-          <a href="checkout.html" class="btn">Buy Now</a>
+          <a href="checkout.html" class="btn" aria-label="Go to 4k Action Camera Checkout page">Buy Now</a>
         </div>
       </div>
     </main>


### PR DESCRIPTION
This pull request improves accessibility in Lab 1 by adding missing `aria-label` attributes to key elements on the checkout and index pages.

- `checkout-train.html`, `checkout_separate.html`, `checkout_single.html`, and `index.html` updated with descriptive ARIA labels.
- Ensures screen readers can correctly interpret and announce interactive elements.
- Improves overall accessibility compliance and user experience.

No functional changes to page logic were made.
