### PR TITLE
Fix production navigation for Lab 2 & Lab 3

### DIFF
--- a/deploy/shared-components/home-index-service/Dockerfile
+++ b/deploy/shared-components/home-index-service/Dockerfile
@@ -43,11 +43,12 @@ COPY docs ./docs
 # Copy lab README files from their original locations
 COPY labs/ ./labs-temp/
 RUN mkdir -p ./docs/labs && \
-    find ./labs-temp -name "README.md" -type f 2>/dev/null | while read readme; do \
-      lab_name=$(basename $(dirname "$readme")); \
-      mkdir -p "./docs/labs/$lab_name" && \
-      cp "$readme" "./docs/labs/$lab_name/README.md"; \
-    done && \
+    find ./labs-temp -mindepth 2 -name "README.md" -type f -exec sh -c '\
+      for readme; do \
+        lab_name=$(basename "$(dirname "$readme")"); \
+        mkdir -p "./docs/labs/$lab_name" && \
+        cp "$readme" "./docs/labs/$lab_name/README.md"; \
+      done' _ {} + && \
     rm -rf ./labs-temp
 
 # Copy catalog info for service metadata

--- a/labs/02-dom-skimming/vulnerable-site/banking.html
+++ b/labs/02-dom-skimming/vulnerable-site/banking.html
@@ -461,23 +461,23 @@
           c2Url = 'https://labs.stg.pcioasis.com/02-dom-skimming-c2'
           writeupUrl = 'https://labs.stg.pcioasis.com/lab-02-writeup'
         } else if (hostname.includes('labs.pcioasis.com')) {
-          homeUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app'
-          c2Url = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app/02-dom-skimming-c2'
-          writeupUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app/lab-02-writeup'
+          homeUrl = 'https://home-index-prd-171147998109.us-central1.run.app'
+          c2Url = 'https://home-index-prd-171147998109.us-central1.run.app/02-dom-skimming-c2'
+          writeupUrl = 'https://home-index-prd-171147998109.us-central1.run.app/lab-02-writeup'
         } else if (hostname.includes('lab-02-dom-skimming')) {
           // Production Cloud Run (combined deployment - nginx + C2 in same container)
-          homeUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app'
+          homeUrl = 'https://home-index-prd-171147998109.us-central1.run.app'
           c2Url = window.location.protocol + '//' + hostname + '/stolen-data'
-          writeupUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app/lab-02-writeup'
+          writeupUrl = 'https://home-index-prd-171147998109.us-central1.run.app/lab-02-writeup'
         } else if (hostname.includes('run.app') && hostname.includes('lab-02')) {
           // Production Cloud Run direct URL
           homeUrl = window.location.origin + '/banking.html'
           c2Url = window.location.protocol + '//' + hostname + '/stolen-data'
-          writeupUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app/lab-02-writeup'
+          writeupUrl = 'https://home-index-prd-171147998109.us-central1.run.app/lab-02-writeup'
         } else {
           homeUrl = window.location.protocol + '//' + hostname
           c2Url = window.location.protocol + '//' + hostname + '/c2'
-          writeupUrl = window.location.protocol + '//' + hostname.replace('lab-02-dom-skimming', 'home-index-prd-mmwwcfi5za-uc.a.run.app') + '/lab-02-writeup'
+          writeupUrl = window.location.protocol + '//' + hostname.replace('lab-02-dom-skimming', 'home-index-prd-171147998109.us-central1.run.app') + '/lab-02-writeup'
         }
 
         // Update navigation buttons

--- a/labs/03-extension-hijacking/malicious-extension/content/content.js
+++ b/labs/03-extension-hijacking/malicious-extension/content/content.js
@@ -34,7 +34,7 @@
     fallbackUrl: 'http://backup-evil.com/data',
 
     // Local development server
-    devUrl: 'http://localhost:9006/stolen-data'
+    devUrl: 'http://localhost:9006/stolen-data',
     healthUrl: 'http://localhost:9006/health',
 
     // Data collection settings

--- a/labs/03-extension-hijacking/vulnerable-site/index.html
+++ b/labs/03-extension-hijacking/vulnerable-site/index.html
@@ -394,23 +394,23 @@
           c2Url = 'https://labs.stg.pcioasis.com/03-extension-hijacking-c2'
           writeupUrl = 'https://labs.stg.pcioasis.com/lab-03-writeup'
         } else if (hostname.includes('labs.pcioasis.com')) {
-          homeUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app'
-          c2Url = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app/03-extension-hijacking-c2'
-          writeupUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app/lab-03-writeup'
+          homeUrl = 'https://home-index-prd-171147998109.us-central1.run.app'
+          c2Url = 'https://home-index-prd-171147998109.us-central1.run.app/03-extension-hijacking-c2'
+          writeupUrl = 'https://home-index-prd-171147998109.us-central1.run.app/lab-03-writeup'
         } else if (hostname.includes('lab-03-extension-hijacking')) {
           // Production Cloud Run
-          homeUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app'
+          homeUrl = 'https://home-index-prd-171147998109.us-central1.run.app'
           c2Url = window.location.protocol + '//' + hostname + '/stolen-data'
-          writeupUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app/lab-03-writeup'
+          writeupUrl = 'https://home-index-prd-171147998109.us-central1.run.app/lab-03-writeup'
         } else if (hostname.includes('run.app') && hostname.includes('lab-03')) {
           // Production Cloud Run direct URL
-          homeUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app'
+          homeUrl = 'https://home-index-prd-171147998109.us-central1.run.app'
           c2Url = window.location.protocol + '//' + hostname + '/stolen-data'
-          writeupUrl = 'https://home-index-prd-mmwwcfi5za-uc.a.run.app/lab-03-writeup'
+          writeupUrl = 'https://home-index-prd-171147998109.us-central1.run.app/lab-03-writeup'
         } else {
           homeUrl = window.location.protocol + '//' + hostname
           c2Url = window.location.protocol + '//' + hostname + '/c2'
-          writeupUrl = window.location.protocol + '//' + hostname.replace('lab-03-extension-hijacking', 'home-index-prd-mmwwcfi5za-uc.a.run.app') + '/lab-03-writeup'
+          writeupUrl = window.location.protocol + '//' + hostname.replace('lab-03-extension-hijacking', 'home-index-prd-171147998109.us-central1.run.app') + '/lab-03-writeup'
         }
 
         // Update lab navigation buttons


### PR DESCRIPTION
This PR updates all broken navigation URLs in Lab 2 and Lab 3 to use the correct production Home Index service.
The old Cloud Run URLs using the deprecated mmwwcfi5za service ID have been removed from the vulnerable site code.

Updates included:
Fixed Back to Labs in Lab 2 to point to the correct Home Index service.
Fixed Lab2 → C2 → Back to Lab to correctly route to /banking.html.
Updated Lab 2 writeup URL to the correct production endpoint.
Updated Lab 3 homeUrl to the correct Home Index service.
Removed all outdated Lab 3 service URLs that caused “Cannot GET /index.html”.