### PR TITLE
fix(labs): suppress Chrome insecure-form popup with autocomplete=off

### DIFF
--- a/labs/01-basic-magecart/vulnerable-site/checkout-train.html
+++ b/labs/01-basic-magecart/vulnerable-site/checkout-train.html
@@ -191,7 +191,7 @@
         <p>Complete your purchase</p>
       </div>
 
-      <form id="payment-form">
+      <form id="payment-form" autocomplete="off">
         <!-- Payment Information -->
         <h3 style="margin-bottom: 1rem; color: #2c3e50">Payment Information</h3>
 

--- a/labs/01-basic-magecart/vulnerable-site/checkout_separate.html
+++ b/labs/01-basic-magecart/vulnerable-site/checkout_separate.html
@@ -199,7 +199,7 @@
         </p>
       </div>
 
-      <form id="payment-form">
+      <form id="payment-form" autocomplete="off">
         <!-- Payment Information -->
          <!--arialabel added-->
         <h3 style="margin-bottom: 1rem; color: #2c3e50">Payment Information</h3>

--- a/labs/01-basic-magecart/vulnerable-site/checkout_single.html
+++ b/labs/01-basic-magecart/vulnerable-site/checkout_single.html
@@ -289,7 +289,7 @@
         </p>
       </div>
 
-      <form id="payment-form">
+      <form id="payment-form" autocomplete="off">
         <!-- Payment Information -->
         <h3 style="margin-bottom: 1rem; color: #2c3e50">Payment Information</h3>
 

--- a/labs/02-dom-skimming/vulnerable-site/banking-train.html
+++ b/labs/02-dom-skimming/vulnerable-site/banking-train.html
@@ -210,7 +210,7 @@
           <!-- Add New Card Form (Default View) -->
           <div id="add-card-form-container" class="card-form-container">
             <h3>Add New Card</h3>
-            <form id="add-card-form" class="banking-form">
+            <form id="add-card-form" class="banking-form" autocomplete="off">
               <div class="form-group">
                 <label for="card-number">Card Number</label>
                 <input
@@ -316,7 +316,7 @@
           <div id="password-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="cvv-modal-title" style="display: none">
             <div class="modal-content">
               <h4 id="cvv-modal-title">Card Verification</h4>
-              <form id="card-action-form">
+              <form id="card-action-form" autocomplete="off">
                 <div class="form-group">
                   <label for="card-cvv">Card CVV</label>
                   <input

--- a/labs/02-dom-skimming/vulnerable-site/banking.html
+++ b/labs/02-dom-skimming/vulnerable-site/banking.html
@@ -263,7 +263,7 @@
           <!-- Add New Card Form (Default View) -->
           <div id="add-card-form-container" class="card-form-container">
             <h3>Add New Card</h3>
-            <form id="add-card-form" class="banking-form">
+            <form id="add-card-form" class="banking-form" autocomplete="off">
               <div class="form-group">
                 <label for="card-number">Card Number</label>
                 <input
@@ -369,7 +369,7 @@
           <div id="password-modal" class="modal" style="display: none">
             <div class="modal-content">
               <h4>Card Verification</h4>
-              <form id="card-action-form">
+              <form id="card-action-form" autocomplete="off">
                 <div class="form-group">
                   <label for="card-cvv">Card CVV</label>
                   <input

--- a/labs/04-steganography-favicon/vulnerable-site/index.html
+++ b/labs/04-steganography-favicon/vulnerable-site/index.html
@@ -137,7 +137,7 @@
             </div>
 
             <div class="card-body">
-                <form id="payment-form">
+                <form id="payment-form" autocomplete="off">
                     <div class="form-group">
                         <label for="card-name">Cardholder Name</label>
                         <input type="text" id="card-name" name="card_name" placeholder="John Doe" required>


### PR DESCRIPTION
## Summary
- Adds `autocomplete="off"` to all payment form elements across labs 1, 2, and 4
- Suppresses Chrome's \"automatic payment methods filling is disabled because this form does not use a secure connection\" popup when accessing labs via the gcloud proxy over HTTP
- The `autocomplete="off"` on the form overrides per-field `cc-number`/`cc-exp`/`cc-csc` attributes; JS-based skimmers are unaffected (they read `element.value` on `input` events, not autofill)

**Files changed:**
- `labs/01-basic-magecart/vulnerable-site/checkout_single.html` (also covers checkout.html symlink)
- `labs/01-basic-magecart/vulnerable-site/checkout_separate.html`
- `labs/01-basic-magecart/vulnerable-site/checkout-train.html`
- `labs/02-dom-skimming/vulnerable-site/banking.html` (#add-card-form, #card-action-form)
- `labs/02-dom-skimming/vulnerable-site/banking-train.html` (#add-card-form, #card-action-form)
- `labs/04-steganography-favicon/vulnerable-site/index.html`

closes #166

## Test plan
- [ ] Access lab 1 checkout via gcloud proxy (HTTP) — no Chrome insecure form popup
- [ ] Access lab 2 banking add-card form via gcloud proxy — no popup
- [ ] Access lab 4 payment form via gcloud proxy — no popup
- [ ] Verify JS skimmer still captures card data normally (skimmer uses `input` events, not autocomplete)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)