### PR TITLE
fix(auth): use relative redirects in auth middleware

### DIFF
--- a/deploy/shared-components/home-index-service/auth/middleware.go
+++ b/deploy/shared-components/home-index-service/auth/middleware.go
@@ -3,10 +3,9 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
-	"os"
+	"net/url"
 	"path"
 	"strings"
 )
@@ -124,7 +123,7 @@ func AuthMiddleware(validator *TokenValidator) func(http.Handler) http.Handler {
 				if validator.IsRequired() {
 					// Auth required but validation failed
 					log.Printf("❌ Authentication required but failed: %v", err)
-					respondAuthError(w, r, http.StatusUnauthorized, "Authentication required", validator.GetMainAppURL())
+					respondAuthError(w, r, http.StatusUnauthorized, "Authentication required")
 					return
 				}
 				// Auth optional, continue without user info
@@ -136,7 +135,7 @@ func AuthMiddleware(validator *TokenValidator) func(http.Handler) http.Handler {
 			// If auth is required but no credentials provided
 			if validator.IsRequired() && ExtractSessionCookie(r) == "" && extractToken(r) == "" {
 				log.Printf("❌ Authentication required but no token provided")
-				respondAuthError(w, r, http.StatusUnauthorized, "Authentication required", validator.GetMainAppURL())
+				respondAuthError(w, r, http.StatusUnauthorized, "Authentication required")
 				return
 			}
 
@@ -149,17 +148,7 @@ func AuthMiddleware(validator *TokenValidator) func(http.Handler) http.Handler {
 					acceptHeader == "" ||
 					strings.Contains(acceptHeader, "*/*")
 				if isBrowserRequest {
-					// Use X-Forwarded-Host if available (when behind proxy like Traefik),
-					// otherwise use request's Host header to avoid container hostname issues
-					scheme := "http"
-					if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-						scheme = "https"
-					}
-					host := r.Header.Get("X-Forwarded-Host")
-					if host == "" {
-						host = r.Host
-					}
-					redirectURL := fmt.Sprintf("%s://%s/sign-in?error=email_not_verified&email=%s", scheme, host, userInfo.Email)
+					redirectURL := "/sign-in?error=email_not_verified&email=" + url.QueryEscape(userInfo.Email)
 					http.Redirect(w, r, redirectURL, http.StatusFound)
 					return
 				}
@@ -233,7 +222,7 @@ func GetUserInfo(r *http.Request) *TokenInfo {
 // respondAuthError sends an authentication error response
 // For browser requests, redirects to sign-in page
 // For API requests, returns JSON error
-func respondAuthError(w http.ResponseWriter, r *http.Request, statusCode int, message string, mainAppURL string) {
+func respondAuthError(w http.ResponseWriter, r *http.Request, statusCode int, message string) {
 	// Check if this is a browser request (has Accept: text/html)
 	acceptHeader := r.Header.Get("Accept")
 	isBrowserRequest := strings.Contains(acceptHeader, "text/html") ||
@@ -241,29 +230,10 @@ func respondAuthError(w http.ResponseWriter, r *http.Request, statusCode int, me
 		strings.Contains(acceptHeader, "*/*")
 
 	if isBrowserRequest {
-		scheme := "http"
-		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-			scheme = "https"
-		}
-		host := r.Header.Get("X-Forwarded-Host")
-		environment := os.Getenv("ENVIRONMENT")
-		if host == "" {
-			if environment == "local" {
-				host = "localhost:8080"
-			} else {
-				host = r.Host
-			}
-		} else if environment == "local" {
-			host = "localhost:8080"
-		}
-		// Normalize 127.0.0.1 → localhost so cookies set at sign-in (localhost domain)
-		// are sent on subsequent requests to the same origin. The gcloud proxy binds on
-		// 127.0.0.1 but the browser uses "localhost" — cookies are domain-specific.
-		if strings.HasPrefix(host, "127.0.0.1:") {
-			host = "localhost:" + strings.TrimPrefix(host, "127.0.0.1:")
-			scheme = "http"
-		}
-		redirectURL := fmt.Sprintf("%s://%s/sign-in?redirect=%s", scheme, host, r.URL.String())
+		// Use a relative redirect so the browser resolves it against the URL it
+		// was actually visiting — works correctly whether accessed via the gcloud
+		// proxy, Traefik, or directly (no host/scheme guessing needed).
+		redirectURL := "/sign-in?redirect=" + url.QueryEscape(r.URL.RequestURI())
 		http.Redirect(w, r, redirectURL, http.StatusFound)
 		return
 	}

--- a/deploy/shared-components/home-index-service/auth/middleware_test.go
+++ b/deploy/shared-components/home-index-service/auth/middleware_test.go
@@ -1,0 +1,105 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRespondAuthError_BrowserRedirectIsRelative(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestURI   string
+		acceptHeader string
+		wantLocation string
+	}{
+		{
+			name:         "plain path",
+			requestURI:   "/lab1",
+			acceptHeader: "text/html",
+			wantLocation: "/sign-in?redirect=%2Flab1",
+		},
+		{
+			name:         "path with query string encodes full RequestURI",
+			requestURI:   "/lab1?foo=bar&baz=qux",
+			acceptHeader: "text/html",
+			wantLocation: "/sign-in?redirect=%2Flab1%3Ffoo%3Dbar%26baz%3Dqux",
+		},
+		{
+			name:         "wildcard Accept treated as browser",
+			requestURI:   "/protected",
+			acceptHeader: "*/*",
+			wantLocation: "/sign-in?redirect=%2Fprotected",
+		},
+		{
+			name:         "empty Accept treated as browser",
+			requestURI:   "/protected",
+			acceptHeader: "",
+			wantLocation: "/sign-in?redirect=%2Fprotected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.requestURI, nil)
+			if tt.acceptHeader != "" {
+				req.Header.Set("Accept", tt.acceptHeader)
+			}
+			w := httptest.NewRecorder()
+
+			respondAuthError(w, req, http.StatusUnauthorized, "Authentication required")
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusFound {
+				t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusFound)
+			}
+			loc := resp.Header.Get("Location")
+			if loc != tt.wantLocation {
+				t.Errorf("Location = %q, want %q", loc, tt.wantLocation)
+			}
+			if strings.HasPrefix(loc, "http") {
+				t.Errorf("Location must be relative, got absolute URL: %q", loc)
+			}
+		})
+	}
+}
+
+// TestRespondAuthError_ProxyHeadersIgnored ensures proxy headers that the old
+// code used for host/scheme inference do not produce an absolute redirect URL.
+func TestRespondAuthError_ProxyHeadersIgnored(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Accept", "text/html")
+	req.Header.Set("X-Forwarded-Host", "labs.pcioasis.com")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+
+	respondAuthError(w, req, http.StatusUnauthorized, "Authentication required")
+
+	loc := w.Result().Header.Get("Location")
+	if strings.HasPrefix(loc, "http") {
+		t.Errorf("proxy headers must not produce an absolute URL, got: %q", loc)
+	}
+	if loc != "/sign-in?redirect=%2Fprotected" {
+		t.Errorf("Location = %q, want /sign-in?redirect=%%2Fprotected", loc)
+	}
+}
+
+func TestRespondAuthError_APIRequestReturnsJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/data", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+
+	respondAuthError(w, req, http.StatusUnauthorized, "Authentication required")
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if loc := resp.Header.Get("Location"); loc != "" {
+		t.Errorf("API request must not redirect, got Location: %q", loc)
+	}
+}


### PR DESCRIPTION
## Summary

- `respondAuthError` now redirects to `/sign-in?redirect=<encoded-uri>` (relative) instead of building an absolute `scheme://host/sign-in?...` URL by guessing from headers.
- The email-not-verified redirect (same file) gets the same treatment.
- Removes the now-unused `mainAppURL` parameter from `respondAuthError` and its two call sites.
- Drops the `fmt` and `os` imports that were only needed for absolute-URL construction.

**Why this matters:** The old header-based host inference breaks behind the gcloud proxy, where `X-Forwarded-Host` or `r.Host` can resolve to an internal Cloud Run hostname. A relative URL is resolved by the browser against the URL it was already visiting, so it works correctly through the proxy, through Traefik, and directly — no inference needed.

This closes the gap identified in #216, which was closed because it bundled an unrelated `deploy_labs.yml` path-filter removal.

## Test plan
- [ ] Sign in through `gcloud run services proxy traefik-stg` — redirect after auth should land on the correct public domain, not an internal hostname
- [ ] Unauthenticated access to a protected lab page should redirect to `/sign-in?redirect=<original-path>`
- [ ] Email-not-verified user should redirect to `/sign-in?error=email_not_verified&email=<addr>`
- [ ] `go build ./...` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)