### PR TITLE
fix(ci): replace networkidle wait with __session cookie poll in auth setup

### DIFF
--- a/test/utils/global-setup-auth.js
+++ b/test/utils/global-setup-auth.js
@@ -159,18 +159,21 @@ module.exports = async () => {
     )
     await page.click('button[type="submit"]')
     await navigationDone
-    // Wait for any pending requests (e.g. server-side session cookie exchange) to settle.
-    await page.waitForLoadState('networkidle', { timeout: 15000 })
 
-    const currentUrl = page.url()
-    if (currentUrl.includes('/sign-in')) {
-      throw new Error('Failed to authenticate: still on sign-in page after submit')
+    // Poll for __session rather than waiting for networkidle.
+    // networkidle requires 500ms with no network activity; background requests
+    // (analytics, lab polling) can prevent that window from ever opening.
+    // Polling the cookie directly tests the actual post-sign-in invariant.
+    const SESSION_POLL_MS = 15000
+    const SESSION_POLL_INTERVAL_MS = 300
+    const pollStart = Date.now()
+    let sessionCookie = null
+    while (Date.now() - pollStart < SESSION_POLL_MS) {
+      const cookies = await context.cookies()
+      sessionCookie = cookies.find(c => c.name === '__session')
+      if (sessionCookie) break
+      await page.waitForTimeout(SESSION_POLL_INTERVAL_MS)
     }
-
-    // Validate that the __session cookie was set — this is what storageState
-    // persists and what auth-check middleware reads on subsequent requests.
-    const cookies = await context.cookies()
-    const sessionCookie = cookies.find(c => c.name === '__session')
     if (!sessionCookie) {
       throw new Error('__session cookie not found after sign-in — auth state will not be usable')
     }


### PR DESCRIPTION
## Summary

- Replaces `page.waitForLoadState('networkidle', { timeout: 15000 })` with a 300ms-interval poll on `context.cookies()` for the `__session` cookie.
- Removes the now-redundant URL check (already guaranteed by the preceding `waitForURL`).

## Why

`networkidle` requires 500ms of zero network activity. Background requests — analytics scripts, lab polling, any JS that fires after the redirect — can prevent that window from ever opening, causing the 15s timeout to fire even though sign-in completed successfully. This is what caused the CI failure in [run 25815511637](https://github.com/pci-tamper-protect/e-skimming-labs/actions/runs/25815511637/job/75842805409).

The `__session` cookie is the actual invariant that matters: once it is present, the auth state is ready to save. Polling for it directly is both faster (exits as soon as the cookie appears) and immune to background network traffic.

## Test plan
- [ ] Auth setup in CI completes without timeout on the next deploy-triggered run
- [ ] Auth setup still works when sign-in takes a couple of seconds (cookie poll waits up to 15s)
- [ ] If `__session` is never set, the error message is still clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)