### PR TITLE
stg->main

### DIFF
--- a/.github/workflows/deploy_labs.yml
+++ b/.github/workflows/deploy_labs.yml
@@ -2,7 +2,7 @@ name: Deploy CloudRun
 
 on:
   pull_request:
-    branches: [main, stg]
+    branches: [stg]
     types: [opened, synchronize, reopened]
     paths:
       # Home components

--- a/.github/workflows/deploy_labs.yml
+++ b/.github/workflows/deploy_labs.yml
@@ -1014,14 +1014,39 @@ jobs:
           docker push "${IMAGE_BASE}:${{ github.sha }}" || { echo "❌ Failed to push shared-c2 image"; exit 1; }
           docker push "${IMAGE_BASE}:latest" || { echo "❌ Failed to push shared-c2 latest"; exit 1; }
 
+      - name: Ensure C2 GCS buckets
+        if: env.LABS_GCP_SA_KEY != '' && env.LABS_GCP_SA_KEY != null
+        run: |
+          ENV="${{ needs.setup.outputs.environment }}"
+          REGION="${{ env.LABS_GAR_LOCATION }}"
+          PROJECT="${{ env.LABS_PROJECT_ID }}"
+          C2_SA="labs-runtime-sa@${PROJECT}.iam.gserviceaccount.com"
+          for lab in lab1 lab2 lab3 lab4; do
+            bucket="labs-c2-${lab}-${ENV}"
+            if ! gcloud storage buckets describe "gs://${bucket}" --project="${PROJECT}" &>/dev/null; then
+              echo "Creating bucket gs://${bucket}..."
+              gcloud storage buckets create "gs://${bucket}" \
+                --project="${PROJECT}" \
+                --location="${REGION}" \
+                --uniform-bucket-level-access \
+                --quiet
+            fi
+            gcloud storage buckets add-iam-policy-binding "gs://${bucket}" \
+              --member="serviceAccount:${C2_SA}" \
+              --role="roles/storage.objectAdmin" \
+              --quiet 2>/dev/null || true
+          done
+          echo "✅ C2 GCS buckets ready"
+
       - name: Deploy shared-c2 to Cloud Run
         if: env.LABS_GCP_SA_KEY != '' && env.LABS_GCP_SA_KEY != null
         run: |
+          ENV="${{ needs.setup.outputs.environment }}"
           source deploy/traefik/lab-labels.sh
           TRAEFIK_LABELS=$(get_lab_labels "shared-c2")
 
           # shared-c2 must be public: browser scripts POST card data without IAM tokens
-          gcloud run deploy shared-c2-${{ needs.setup.outputs.environment }} \
+          gcloud run deploy shared-c2-${ENV} \
             --image=${{ env.LABS_GAR_LOCATION }}-docker.pkg.dev/${{ env.LABS_PROJECT_ID }}/${{ env.LABS_REPOSITORY }}/shared-c2:${{ github.sha }} \
             --region=${{ env.LABS_GAR_LOCATION }} \
             --platform=managed \
@@ -1030,10 +1055,10 @@ jobs:
             --port=3000 \
             --memory=512Mi \
             --cpu=1 \
-            --min-instances=0 \
+            --min-instances=1 \
             --max-instances=5 \
-            --set-env-vars="ENVIRONMENT=${{ needs.setup.outputs.environment }}" \
-            --labels="environment=${{ needs.setup.outputs.environment }},component=shared-c2,project=e-skimming-labs,${TRAEFIK_LABELS}"
+            --set-env-vars="ENVIRONMENT=${ENV},LAB1_BUCKET=labs-c2-lab1-${ENV},LAB2_BUCKET=labs-c2-lab2-${ENV},LAB3_BUCKET=labs-c2-lab3-${ENV},LAB4_BUCKET=labs-c2-lab4-${ENV}" \
+            --labels="environment=${ENV},component=shared-c2,project=e-skimming-labs,${TRAEFIK_LABELS}"
 
   # ============================================================================
   # LABS - Individual lab services (matrix parallelization, only changed labs)

--- a/.github/workflows/deploy_labs.yml
+++ b/.github/workflows/deploy_labs.yml
@@ -412,19 +412,6 @@ jobs:
           # Also configure cross-project access for golden images
           gcloud auth configure-docker us-central1-docker.pkg.dev
 
-      - name: Enable required APIs on home project
-        if: env.HOME_GCP_SA_KEY != '' && env.HOME_GCP_SA_KEY != null
-        run: |
-          # identitytoolkit.googleapis.com must be enabled on the CALLING project (labs-home-*)
-          # because Google checks API quota/enablement against the service account's project,
-          # not the Firebase project. Without this, CreateSessionCookie returns 403.
-          gcloud services enable \
-            identitytoolkit.googleapis.com \
-            run.googleapis.com \
-            artifactregistry.googleapis.com \
-            --project="${{ env.HOME_PROJECT_ID }}" --quiet
-          echo "✅ Required APIs enabled on ${{ env.HOME_PROJECT_ID }}"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/deploy/deploy-all.sh
+++ b/deploy/deploy-all.sh
@@ -88,18 +88,36 @@ cd "$REPO_ROOT"
 # identitytoolkit.googleapis.com must be enabled on the CALLING project (labs-home-*)
 # because Google checks API quota/enablement against the service account's project,
 # not the Firebase project. Without this, CreateSessionCookie returns 403.
-echo "🔧 Enabling required APIs..."
-gcloud services enable \
+ensure_service_enabled() {
+  local project_id=$1
+  shift
+  local service
+  for service in "$@"; do
+    if gcloud services list \
+      --project="${project_id}" \
+      --filter="config.name:${service}" \
+      --limit=1 \
+      --format="value(config.name)" \
+      | grep -q "${service}"; then
+      echo "   ✔ ${service} already enabled on ${project_id}"
+    else
+      echo "   🔧 Enabling ${service} on ${project_id}..."
+      gcloud services enable "${service}" --project="${project_id}" --quiet
+      echo "   ✅ ${service} enabled"
+    fi
+  done
+}
+
+echo "🔧 Ensuring required APIs are enabled..."
+ensure_service_enabled "${HOME_PROJECT_ID}" \
   identitytoolkit.googleapis.com \
   run.googleapis.com \
-  artifactregistry.googleapis.com \
-  --project="${HOME_PROJECT_ID}" --quiet
-gcloud services enable \
+  artifactregistry.googleapis.com
+ensure_service_enabled "${LABS_PROJECT_ID}" \
   run.googleapis.com \
   artifactregistry.googleapis.com \
-  storage.googleapis.com \
-  --project="${LABS_PROJECT_ID}" --quiet
-echo "   ✅ APIs enabled"
+  storage.googleapis.com
+echo ""
 echo ""
 
 # GCS bucket names for shared-c2 per-lab storage

--- a/deploy/shared-components/home-index-service/auth/middleware.go
+++ b/deploy/shared-components/home-index-service/auth/middleware.go
@@ -3,10 +3,9 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
-	"os"
+	"net/url"
 	"path"
 	"strings"
 )
@@ -124,7 +123,7 @@ func AuthMiddleware(validator *TokenValidator) func(http.Handler) http.Handler {
 				if validator.IsRequired() {
 					// Auth required but validation failed
 					log.Printf("❌ Authentication required but failed: %v", err)
-					respondAuthError(w, r, http.StatusUnauthorized, "Authentication required", validator.GetMainAppURL())
+					respondAuthError(w, r, http.StatusUnauthorized, "Authentication required")
 					return
 				}
 				// Auth optional, continue without user info
@@ -136,7 +135,7 @@ func AuthMiddleware(validator *TokenValidator) func(http.Handler) http.Handler {
 			// If auth is required but no credentials provided
 			if validator.IsRequired() && ExtractSessionCookie(r) == "" && extractToken(r) == "" {
 				log.Printf("❌ Authentication required but no token provided")
-				respondAuthError(w, r, http.StatusUnauthorized, "Authentication required", validator.GetMainAppURL())
+				respondAuthError(w, r, http.StatusUnauthorized, "Authentication required")
 				return
 			}
 
@@ -149,17 +148,7 @@ func AuthMiddleware(validator *TokenValidator) func(http.Handler) http.Handler {
 					acceptHeader == "" ||
 					strings.Contains(acceptHeader, "*/*")
 				if isBrowserRequest {
-					// Use X-Forwarded-Host if available (when behind proxy like Traefik),
-					// otherwise use request's Host header to avoid container hostname issues
-					scheme := "http"
-					if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-						scheme = "https"
-					}
-					host := r.Header.Get("X-Forwarded-Host")
-					if host == "" {
-						host = r.Host
-					}
-					redirectURL := fmt.Sprintf("%s://%s/sign-in?error=email_not_verified&email=%s", scheme, host, userInfo.Email)
+					redirectURL := "/sign-in?error=email_not_verified&email=" + url.QueryEscape(userInfo.Email)
 					http.Redirect(w, r, redirectURL, http.StatusFound)
 					return
 				}
@@ -233,7 +222,7 @@ func GetUserInfo(r *http.Request) *TokenInfo {
 // respondAuthError sends an authentication error response
 // For browser requests, redirects to sign-in page
 // For API requests, returns JSON error
-func respondAuthError(w http.ResponseWriter, r *http.Request, statusCode int, message string, mainAppURL string) {
+func respondAuthError(w http.ResponseWriter, r *http.Request, statusCode int, message string) {
 	// Check if this is a browser request (has Accept: text/html)
 	acceptHeader := r.Header.Get("Accept")
 	isBrowserRequest := strings.Contains(acceptHeader, "text/html") ||
@@ -241,29 +230,10 @@ func respondAuthError(w http.ResponseWriter, r *http.Request, statusCode int, me
 		strings.Contains(acceptHeader, "*/*")
 
 	if isBrowserRequest {
-		scheme := "http"
-		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-			scheme = "https"
-		}
-		host := r.Header.Get("X-Forwarded-Host")
-		environment := os.Getenv("ENVIRONMENT")
-		if host == "" {
-			if environment == "local" {
-				host = "localhost:8080"
-			} else {
-				host = r.Host
-			}
-		} else if environment == "local" {
-			host = "localhost:8080"
-		}
-		// Normalize 127.0.0.1 → localhost so cookies set at sign-in (localhost domain)
-		// are sent on subsequent requests to the same origin. The gcloud proxy binds on
-		// 127.0.0.1 but the browser uses "localhost" — cookies are domain-specific.
-		if strings.HasPrefix(host, "127.0.0.1:") {
-			host = "localhost:" + strings.TrimPrefix(host, "127.0.0.1:")
-			scheme = "http"
-		}
-		redirectURL := fmt.Sprintf("%s://%s/sign-in?redirect=%s", scheme, host, r.URL.String())
+		// Use a relative redirect so the browser resolves it against the URL it
+		// was actually visiting — works correctly whether accessed via the gcloud
+		// proxy, Traefik, or directly (no host/scheme guessing needed).
+		redirectURL := "/sign-in?redirect=" + url.QueryEscape(r.URL.RequestURI())
 		http.Redirect(w, r, redirectURL, http.StatusFound)
 		return
 	}

--- a/deploy/shared-components/home-index-service/auth/middleware_test.go
+++ b/deploy/shared-components/home-index-service/auth/middleware_test.go
@@ -1,0 +1,105 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRespondAuthError_BrowserRedirectIsRelative(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestURI   string
+		acceptHeader string
+		wantLocation string
+	}{
+		{
+			name:         "plain path",
+			requestURI:   "/lab1",
+			acceptHeader: "text/html",
+			wantLocation: "/sign-in?redirect=%2Flab1",
+		},
+		{
+			name:         "path with query string encodes full RequestURI",
+			requestURI:   "/lab1?foo=bar&baz=qux",
+			acceptHeader: "text/html",
+			wantLocation: "/sign-in?redirect=%2Flab1%3Ffoo%3Dbar%26baz%3Dqux",
+		},
+		{
+			name:         "wildcard Accept treated as browser",
+			requestURI:   "/protected",
+			acceptHeader: "*/*",
+			wantLocation: "/sign-in?redirect=%2Fprotected",
+		},
+		{
+			name:         "empty Accept treated as browser",
+			requestURI:   "/protected",
+			acceptHeader: "",
+			wantLocation: "/sign-in?redirect=%2Fprotected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.requestURI, nil)
+			if tt.acceptHeader != "" {
+				req.Header.Set("Accept", tt.acceptHeader)
+			}
+			w := httptest.NewRecorder()
+
+			respondAuthError(w, req, http.StatusUnauthorized, "Authentication required")
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusFound {
+				t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusFound)
+			}
+			loc := resp.Header.Get("Location")
+			if loc != tt.wantLocation {
+				t.Errorf("Location = %q, want %q", loc, tt.wantLocation)
+			}
+			if strings.HasPrefix(loc, "http") {
+				t.Errorf("Location must be relative, got absolute URL: %q", loc)
+			}
+		})
+	}
+}
+
+// TestRespondAuthError_ProxyHeadersIgnored ensures proxy headers that the old
+// code used for host/scheme inference do not produce an absolute redirect URL.
+func TestRespondAuthError_ProxyHeadersIgnored(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Accept", "text/html")
+	req.Header.Set("X-Forwarded-Host", "labs.pcioasis.com")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+
+	respondAuthError(w, req, http.StatusUnauthorized, "Authentication required")
+
+	loc := w.Result().Header.Get("Location")
+	if strings.HasPrefix(loc, "http") {
+		t.Errorf("proxy headers must not produce an absolute URL, got: %q", loc)
+	}
+	if loc != "/sign-in?redirect=%2Fprotected" {
+		t.Errorf("Location = %q, want /sign-in?redirect=%%2Fprotected", loc)
+	}
+}
+
+func TestRespondAuthError_APIRequestReturnsJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/data", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+
+	respondAuthError(w, req, http.StatusUnauthorized, "Authentication required")
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if loc := resp.Header.Get("Location"); loc != "" {
+		t.Errorf("API request must not redirect, got Location: %q", loc)
+	}
+}

--- a/deploy/shared-components/home-index-service/main.go
+++ b/deploy/shared-components/home-index-service/main.go
@@ -696,15 +696,36 @@ func main() {
 		// Build absolute URL for redirects - ForwardAuth resolves relative URLs against its own address
 		// which causes browser to redirect to internal hostname (e.g., home-index:8080) instead of public hostname
 		buildRedirectURL := func(path string) string {
-			// Prefer an explicit public base URL if configured (e.g., https://labs.example.com)
-			if publicBase := os.Getenv("PUBLIC_BASE_URL"); publicBase != "" {
-				if u, err := url.Parse(publicBase); err == nil && u.Scheme != "" && u.Host != "" {
+			if rawBase := strings.TrimSpace(os.Getenv("PUBLIC_BASE_URL")); rawBase != "" {
+				normalized := strings.TrimRight(rawBase, "/")
+				if !strings.Contains(normalized, "://") {
+					normalized = "https://" + normalized
+				}
+				if u, err := url.Parse(normalized); err == nil && u.Scheme != "" && u.Host != "" {
 					return fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, path)
 				}
+				log.Printf("⚠️ PUBLIC_BASE_URL invalid, falling back: %s", rawBase)
+			}
+
+			proxyHost := os.Getenv("PROXY_HOST")
+			proxyPort := os.Getenv("PROXY_PORT")
+			if proxyHost != "" && proxyPort != "" {
+				if proxyHost == "127.0.0.1" {
+					proxyHost = "localhost"
+				}
+				return fmt.Sprintf("http://%s:%s%s", proxyHost, proxyPort, path)
+			}
+
+			if envDomain := os.Getenv("DOMAIN"); envDomain != "" {
+				scheme := "https"
+				lowerDomain := strings.ToLower(envDomain)
+				if strings.Contains(lowerDomain, "localhost") || strings.Contains(lowerDomain, "127.") {
+					scheme = "http"
+				}
+				return fmt.Sprintf("%s://%s%s", scheme, envDomain, path)
 			}
 
 			scheme := "http"
-			// X-Forwarded-Proto can be comma-separated (e.g., "https,http"); use the first value
 			if xfProto := r.Header.Get("X-Forwarded-Proto"); xfProto != "" {
 				firstProto := strings.TrimSpace(strings.SplitN(xfProto, ",", 2)[0])
 				if strings.EqualFold(firstProto, "https") {
@@ -714,26 +735,21 @@ func main() {
 				scheme = "https"
 			}
 
-			// Prefer X-Forwarded-Host when present, but fall back to r.Host
 			host := r.Header.Get("X-Forwarded-Host")
 			if host == "" {
 				host = r.Host
 			}
 
 			environment := os.Getenv("ENVIRONMENT")
-			// Treat hosts without a dot (e.g., "home-index:8080") as internal/invalid for redirects
 			isLikelyInternalHost := !strings.Contains(host, ".")
 			if environment == "local" || isLikelyInternalHost {
-				// In local environment, or when we detect an internal hostname, use localhost:8080
 				host = "localhost:8080"
 			}
-			// Normalize 127.0.0.1 → localhost: the gcloud proxy rewrites Location headers to
-			// use 127.0.0.1 as the host, but cookies are set for the "localhost" domain.
-			// Using 127.0.0.1 in the redirect URL causes cookie domain mismatch.
 			if strings.HasPrefix(host, "127.0.0.1:") {
 				host = "localhost:" + strings.TrimPrefix(host, "127.0.0.1:")
 				scheme = "http"
 			}
+
 			return fmt.Sprintf("%s://%s%s", scheme, host, path)
 		}
 

--- a/test/utils/global-setup-auth.js
+++ b/test/utils/global-setup-auth.js
@@ -159,18 +159,21 @@ module.exports = async () => {
     )
     await page.click('button[type="submit"]')
     await navigationDone
-    // Wait for any pending requests (e.g. server-side session cookie exchange) to settle.
-    await page.waitForLoadState('networkidle', { timeout: 15000 })
 
-    const currentUrl = page.url()
-    if (currentUrl.includes('/sign-in')) {
-      throw new Error('Failed to authenticate: still on sign-in page after submit')
+    // Poll for __session rather than waiting for networkidle.
+    // networkidle requires 500ms with no network activity; background requests
+    // (analytics, lab polling) can prevent that window from ever opening.
+    // Polling the cookie directly tests the actual post-sign-in invariant.
+    const SESSION_POLL_MS = 15000
+    const SESSION_POLL_INTERVAL_MS = 300
+    const pollStart = Date.now()
+    let sessionCookie = null
+    while (Date.now() - pollStart < SESSION_POLL_MS) {
+      const cookies = await context.cookies()
+      sessionCookie = cookies.find(c => c.name === '__session')
+      if (sessionCookie) break
+      await page.waitForTimeout(SESSION_POLL_INTERVAL_MS)
     }
-
-    // Validate that the __session cookie was set — this is what storageState
-    // persists and what auth-check middleware reads on subsequent requests.
-    const cookies = await context.cookies()
-    const sessionCookie = cookies.find(c => c.name === '__session')
     if (!sessionCookie) {
       throw new Error('__session cookie not found after sign-in — auth state will not be usable')
     }


### PR DESCRIPTION
This PR (staging → main) hardens auth/redirect handling in the home-index service, simplifies post-sign-in waiting logic in Playwright global setup, and refines the CI/CD pipeline by moving API enablement into an idempotent helper and adding GCS bucket provisioning for the shared-c2 service.

**Changes:**
- Auth redirects in `home-index-service` are now relative (no host/scheme guessing); `buildRedirectURL` adds a layered fallback chain (`PUBLIC_BASE_URL` → `PROXY_HOST/PORT` → `DOMAIN` → forwarded headers). Tests added for the relative-redirect behavior.
- Global Playwright auth setup polls for the `__session` cookie instead of waiting for `networkidle`, which background polling/analytics requests can prevent from ever settling.
- Deployment refactors: `deploy-all.sh` gains an idempotent `ensure_service_enabled` helper; the GitHub Actions workflow drops the inline API-enable step, adds GCS bucket provisioning for shared-c2, and sets `--min-instances=1` for shared-c2.