### PR TITLE
fix(ci): restrict deploy PR trigger to stg-targeting PRs only

### DIFF
--- a/.github/workflows/deploy_labs.yml
+++ b/.github/workflows/deploy_labs.yml
@@ -2,7 +2,7 @@ name: Deploy CloudRun
 
 on:
   pull_request:
-    branches: [main, stg]
+    branches: [stg]
     types: [opened, synchronize, reopened]
     paths:
       # Home components


### PR DESCRIPTION
## Summary

- Changes `branches: [main, stg]` → `branches: [stg]` on the `pull_request` trigger in `deploy_labs.yml`.

## Why

PR #221 (stg→main) failed with:

> Branch "refs/pull/221/merge" is not allowed to deploy to PRD due to environment protection rules.

The `PRD` environment has `deployment_branch_policy: protected_branches: true`. A PR merge ref is not a protected branch, so GitHub rejects the deployment.

**The real fix is the trigger scope.** PRD should only be deployed on `push` to `main` (i.e. after the merge is complete and `main` is the ref). There is no value in a PRD preview deploy during stg→main PR review — the changes were already validated in STG. Feature PRs targeting `stg` continue to get STG preview deploys as before.

## Test plan
- [ ] A new feature PR targeting `stg` still triggers the deploy workflow and deploys to STG
- [ ] A new stg→main PR does **not** trigger the deploy workflow at all
- [ ] Merging stg→main (push to `main`) still triggers a PRD deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)