### PR TITLE
fix(ci): unblock stg deploy and improve test signal quality

### DIFF
--- a/.github/workflows/deploy_labs.yml
+++ b/.github/workflows/deploy_labs.yml
@@ -1016,6 +1016,7 @@ jobs:
 
       - name: Ensure C2 GCS buckets
         if: env.LABS_GCP_SA_KEY != '' && env.LABS_GCP_SA_KEY != null
+        continue-on-error: true  # labs-deploy-sa may lack storage.buckets.create; buckets pre-created via deploy-all.sh
         run: |
           ENV="${{ needs.setup.outputs.environment }}"
           REGION="${{ env.LABS_GAR_LOCATION }}"
@@ -2249,6 +2250,7 @@ jobs:
 
       - name: Comment test results on commit
         if: always()
+        continue-on-error: true  # GITHUB_TOKEN may lack commit:write on push to main; don't fail workflow
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -287,6 +287,14 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
+      - name: Fail if deploy workflow failed (tests were not run)
+        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure'
+        run: |
+          echo "❌ E2E tests were not run because the triggering deploy workflow failed."
+          echo "Deploy run: ${{ github.event.workflow_run.html_url }}"
+          echo "Fix the deploy pipeline first, then re-run."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/deploy/deploy-all.sh
+++ b/deploy/deploy-all.sh
@@ -95,7 +95,7 @@ ensure_service_enabled() {
   for service in "$@"; do
     if gcloud services list \
       --project="${project_id}" \
-      --filter="config.name:${service}" \
+      --filter="config.name=${service}" \
       --limit=1 \
       --format="value(config.name)" \
       | grep -q "${service}"; then

--- a/deploy/shared-components/home-index-service/main.go
+++ b/deploy/shared-components/home-index-service/main.go
@@ -719,7 +719,7 @@ func main() {
 			if envDomain := os.Getenv("DOMAIN"); envDomain != "" {
 				scheme := "https"
 				lowerDomain := strings.ToLower(envDomain)
-				if strings.Contains(lowerDomain, "localhost") || strings.Contains(lowerDomain, "127.") {
+				if strings.Contains(lowerDomain, "localhost") || strings.HasPrefix(lowerDomain, "127.") {
 					scheme = "http"
 				}
 				return fmt.Sprintf("%s://%s%s", scheme, envDomain, path)

--- a/test/e2e/c2-dashboard-display.spec.js
+++ b/test/e2e/c2-dashboard-display.spec.js
@@ -34,12 +34,26 @@ dashboardTests('C2 Dashboard Display', () => {
     await page.fill('#expiry', '1228')
     await page.fill('#cvv', cvv)
 
+    // Start listening for the skimmer POST before clicking — the click fires
+    // the skimmer's submit handler which POSTs after a 100ms delay.
+    const collectPostPromise = page.waitForResponse(
+      resp => resp.url().includes('/lab1/c2/collect') && resp.request().method() === 'POST',
+      { timeout: 15000 }
+    ).catch(() => null) // don't throw if POST never arrives; let matchFound fail with clear message
+
     const submitTime = Date.now()
     await page.click('.submit-btn')
     console.log(`📤 Submitted at ${new Date(submitTime).toISOString()}`)
 
     // ── 3. Wait for the skimmer POST to reach C2 ───────────────────────────────
-    await page.waitForTimeout(2000)
+    const collectResp = await collectPostPromise
+    if (collectResp) {
+      console.log(`📡 Skimmer POST confirmed (status: ${collectResp.status()})`)
+    } else {
+      console.warn('⚠️  Skimmer POST to /lab1/c2/collect not detected within 15s')
+    }
+    // Extra wait for GCS write to complete before reading dashboard
+    await page.waitForTimeout(1500)
 
     // ── 4. Navigate to C2 dashboard ────────────────────────────────────────────
     await page.goto(`${currentEnv.lab1.c2}`)
@@ -173,12 +187,26 @@ dashboardTests('C2 Dashboard Display', () => {
 
     const submitBtn = page.locator('#add-card-form button[type="submit"]')
     await submitBtn.scrollIntoViewIfNeeded()
+
+    // Start listening for the skimmer POST before clicking
+    const collectPostPromise = page.waitForResponse(
+      resp => resp.url().includes('/lab2/c2/collect') && resp.request().method() === 'POST',
+      { timeout: 15000 }
+    ).catch(() => null)
+
     const submitTime = Date.now()
     await submitBtn.click({ force: true })
     console.log(`📤 Submitted at ${new Date(submitTime).toISOString()}`)
 
     // ── 3. Wait for the skimmer POST to reach C2 ───────────────────────────────
-    await page.waitForTimeout(2000)
+    const collectResp = await collectPostPromise
+    if (collectResp) {
+      console.log(`📡 Skimmer POST confirmed (status: ${collectResp.status()})`)
+    } else {
+      console.warn('⚠️  Skimmer POST to /lab2/c2/collect not detected within 15s')
+    }
+    // Extra wait for GCS write to complete before reading dashboard
+    await page.waitForTimeout(1500)
 
     // ── 4. Navigate to C2 dashboard ────────────────────────────────────────────
     await page.goto(`${currentEnv.lab2.c2}`)


### PR DESCRIPTION
## Summary

- **deploy_labs.yml**: Add `continue-on-error: true` to "Ensure C2 GCS buckets" step — `labs-deploy-sa` lacks `storage.buckets.create`; this was blocking the entire shared-c2 deploy. Buckets should be pre-created once via `deploy-all.sh`.
- **deploy_labs.yml**: Add `continue-on-error: true` to "Comment test results on commit" — `GITHUB_TOKEN` lacks `metadata:write` on push-to-main, causing `e2e-tests-merge` to fail and making the prd deploy conclusion `failure`.
- **test.yml**: Make `e2e-tests-summary` fail (not silently pass) when triggered by a failed deploy workflow — was misleadingly showing green with zero tests.
- **c2-dashboard-display.spec.js**: Replace fixed 2s wait with `waitForResponse` to confirm skimmer POST was received before checking dashboard; add 1.5s buffer for GCS write.
- **deploy-all.sh**: Use exact-match filter `=` (not substring `:`) for API enablement check (Copilot #221).
- **main.go**: Use `HasPrefix` for `127.` loopback check instead of `Contains` (Copilot #221).

## Test plan

- [ ] Merge into stg and confirm `deploy-shared-c2` job completes (GCS step shows warning, not failure)
- [ ] Confirm `e2e-tests-merge` no longer fails on prd deploys
- [ ] Trigger a failing deploy and confirm `test.yml` summary now shows ❌ instead of ✅
- [ ] Confirm c2-dashboard tests pick up the skimmer POST response in logs

## Note on GCS buckets

If `labs-c2-lab{1-4}-stg` buckets don't exist yet, run locally:
```
gcloud auth login
./deploy/deploy-all.sh stg
```
This creates the buckets and grants `labs-runtime-sa` objectAdmin access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)