### PR TITLE
fix(auth): remove token log line to resolve CodeQL taint analysis

### DIFF
--- a/deploy/shared-components/home-index-service/main.go
+++ b/deploy/shared-components/home-index-service/main.go
@@ -2319,7 +2319,6 @@ func serveAuthUser(w http.ResponseWriter, r *http.Request, validator *auth.Token
 				})
 				return
 			}
-			log.Printf("🔍 /api/auth/user - Token found: %s", sanitizeToken(token))
 			var err error
 			userInfo, err = validator.ValidateToken(r.Context(), token)
 			if err != nil || userInfo == nil {


### PR DESCRIPTION
## Summary

- Removes `log.Printf("... Token found: %s", sanitizeToken(token))` from `serveAuthUser` in `home-index-service/main.go`
- CodeQL traces the taint from the HTTP request through `sanitizeToken` to the log call — the wrapper doesn't break the taint chain
- The validation outcome (success or failure) is already logged on the downstream paths, so this line adds no diagnostic value

## Fixes

Resolves the two CodeQL findings on PR #230:
- "Clear-text logging of sensitive information"
- "Log entries created from user input"

🤖 Generated with [Claude Code](https://claude.com/claude-code)