### PR TITLE
fix(routing): add home-index to ruleMap so /blog and other paths route correctly

### DIFF
--- a/deploy/traefik/cmd/generate-routes/main.go
+++ b/deploy/traefik/cmd/generate-routes/main.go
@@ -21,6 +21,7 @@ const (
 )
 
 var ruleMap = map[string]string{
+	"home-index":         "PathPrefix(`/`)",
 	"home-index-root":    "PathPrefix(`/`)",
 	"home-index-signin":  "Path(`/sign-in`) || Path(`/sign-up`)",
 	"home-seo":           "PathPrefix(`/api/seo`)",


### PR DESCRIPTION
## Summary

The `generate-lab-labels.sh` script converts `rule=PathPrefix('/')` to `rule_id=<router-name>` because Cloud Run labels cannot contain backticks or parentheses. For the `home-index` router this produces `rule_id=home-index`. The `generate-routes` tool's `ruleMap` only had `"home-index-root"` — the `"home-index"` key was missing.

Without a matching entry, the tool fell back to using the literal string `"home-index"` as the Traefik rule expression, which is invalid syntax. Traefik silently drops such routers, leaving the catch-all unregistered and paths like `/blog`, `/mitre-attack`, and `/lab-01-writeup` unrouted.

## Root cause chain

1. `docker-compose.yml`: `traefik.http.routers.home-index.rule=PathPrefix('/')`
2. `generate-lab-labels.sh`: converts to `rule_id=home-index` (strips backticks)
3. `ruleMap` in `generate-routes/main.go`: `"home-index"` → missing → falls back to literal `"home-index"` as rule
4. Traefik: invalid rule → router disabled → `/blog` and friends hit no router

## Fix

Add `"home-index": "PathPrefix('/')"` alongside the existing `"home-index-root"` alias.

Companion fix in provider: pci-tamper-protect/traefik-cloudrun-provider#4

## Test plan

- [ ] After deploying the updated Traefik provider, `labs.pcioasis.com/blog` renders the blog page
- [ ] `labs.pcioasis.com/` still serves the homepage
- [ ] `labs.pcioasis.com/mitre-attack` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)