### PR TITLE
Document AI assistant extension guardrails

### DIFF
--- a/labs/03-extension-hijacking/AI_ASSISTANT_EXTENSION_THREAT_MODEL.md
+++ b/labs/03-extension-hijacking/AI_ASSISTANT_EXTENSION_THREAT_MODEL.md
@@ -1,0 +1,107 @@
+# AI Assistant Extension Threat Model
+
+This note extends Lab 3 with a defensive review of official AI browser
+assistants. It is intentionally limited to threat modeling, detection, and
+control design. It does not include prompt payloads, extraction steps, or
+instructions for collecting payment data.
+
+## Why This Matters
+
+Classic extension hijacking assumes the victim installs a malicious or
+compromised extension. AI browser assistants introduce a related but different
+risk: a trusted assistant may be allowed to read page content, execute page
+automation, or act inside an authenticated browser session. If untrusted page
+content can influence that assistant, prompt injection becomes a way to turn
+legitimate assistant capabilities into data access or unsafe actions.
+
+For payment pages, treat AI browser assistants as privileged software whenever
+they can:
+
+- read visible page content or screenshots;
+- inspect DOM state or run JavaScript on the page;
+- fill forms, click buttons, or publish content;
+- retain browsing context, memories, or task state;
+- access an authenticated tab where the user can see sensitive data.
+
+## Documented Guardrail Examples
+
+The following observations are based on vendor documentation and should be
+rechecked before each lab release because browser-assistant controls change
+quickly.
+
+| Product surface | Documented page access | Documented guardrails |
+| --- | --- | --- |
+| Claude in Chrome | Anthropic says Claude can interact with sites, read page content, fill forms, click buttons, and, when JavaScript execution is enabled, access the same page data the browser can access. | Per-domain JavaScript permission prompts, content classifiers for suspicious instructions, site blocklists for high-risk categories, high-risk action confirmations, organizational allowlists/blocklists, and guidance to avoid sensitive pages. |
+| ChatGPT Atlas page visibility | OpenAI documents site-level controls for whether ChatGPT can read page content for on-page help and summaries. | Per-site page-visibility disable controls, browser memory separation from ChatGPT memory, extension management, payment-method and password settings, and guidance to disable visibility on financial, medical, or other sensitive personal-data sites. |
+
+These controls reduce risk, but they should not be treated as security
+boundaries for payment data. A lab should measure what the control prevents,
+what the control asks the user to approve, and what remains visible to the
+assistant before any user approval.
+
+## Safe Lab Variant
+
+Use a synthetic checkout page and synthetic test card values only. The goal is
+to test whether defensive controls detect or block risky assistant behavior,
+not to bypass a real assistant or collect real account data.
+
+Recommended variant:
+
+1. Load the Lab 3 checkout with deterministic fake card fields and a clear
+   training banner.
+2. Add benign hidden and visible untrusted content that asks the assistant to
+   ignore the user and perform a clearly disallowed sensitive action.
+3. Ask the assistant a harmless user task such as summarizing checkout errors.
+4. Record whether the assistant reports the untrusted instruction, refuses to
+   access card-like fields, asks for confirmation, or attempts unrelated page
+   actions.
+5. Repeat with page visibility disabled, JavaScript disabled, and high-risk
+   site categories blocked when the product supports those controls.
+
+Do not test against real payment sites, real accounts, stored cards, browser
+password stores, or non-consenting users.
+
+## Detection Signals
+
+Defenders should monitor for behaviors that indicate an AI assistant has become
+a privileged data path:
+
+- assistant requests to read or summarize payment, password, token, or account
+  recovery fields;
+- automation plans that include copying form values, taking screenshots of
+  sensitive areas, or moving data between sites;
+- page JavaScript execution requests on checkout, banking, healthcare, or admin
+  pages;
+- repeated user-confirmation prompts after untrusted page content appears;
+- assistant output that includes field labels, masked-card fragments, session
+  identifiers, or DOM attribute names from sensitive forms;
+- browser memories or task summaries created from payment flows.
+
+## Defensive Controls To Evaluate
+
+Use this checklist when comparing official AI assistants or enterprise browser
+policies:
+
+- Site-level page visibility can be disabled for checkout and account pages.
+- JavaScript execution requires per-domain approval and can be revoked.
+- High-risk categories include payment, banking, crypto, healthcare, and admin
+  consoles.
+- Sensitive actions require confirmation tied to the exact action and target.
+- The assistant distinguishes user instructions from page, email, document, and
+  comment content.
+- Output filters redact common secrets, but documentation states that filters
+  are not the only security boundary.
+- Enterprise policy can centrally allowlist or block assistant access.
+- Audit logs show when the assistant read page content, ran JavaScript, clicked,
+  typed, copied, or created memories.
+- Test coverage includes hidden text, user-generated reviews, iframe content,
+  email previews, and checkout error messages.
+
+## References
+
+- Anthropic: Using Claude in Chrome safely
+  https://support.claude.com/en/articles/12902428-using-claude-in-chrome-safely
+- Anthropic: Piloting Claude in Chrome
+  https://claude.com/blog/claude-for-chrome
+- OpenAI: Web Browsing Settings on ChatGPT Atlas
+  https://help.openai.com/en/articles/12625059-web-browsing-settings-on-chatgpt-atlas

--- a/labs/03-extension-hijacking/Lab03-README.md
+++ b/labs/03-extension-hijacking/Lab03-README.md
@@ -759,6 +759,10 @@ For ML training and security analysis, key detection patterns include:
    capabilities
 4. **User Education**: Training on extension risks and verification
 5. **Enterprise Controls**: Centralized extension management and allowlisting
+6. **AI Assistant Controls**: Review official AI browser assistants as
+   privileged page readers and action takers. See
+   [`AI_ASSISTANT_EXTENSION_THREAT_MODEL.md`](AI_ASSISTANT_EXTENSION_THREAT_MODEL.md)
+   for a defensive guardrail checklist.
 
 ## Comparison with Previous Labs
 

--- a/labs/03-extension-hijacking/README.md
+++ b/labs/03-extension-hijacking/README.md
@@ -759,6 +759,10 @@ For ML training and security analysis, key detection patterns include:
    capabilities
 4. **User Education**: Training on extension risks and verification
 5. **Enterprise Controls**: Centralized extension management and allowlisting
+6. **AI Assistant Controls**: Review official AI browser assistants as
+   privileged page readers and action takers. See
+   [`AI_ASSISTANT_EXTENSION_THREAT_MODEL.md`](AI_ASSISTANT_EXTENSION_THREAT_MODEL.md)
+   for a defensive guardrail checklist.
 
 ## Comparison with Previous Labs
 


### PR DESCRIPTION
Addresses #242.

## Summary
- add a defensive AI assistant extension threat model for Lab 3
- document documented guardrail categories for Claude in Chrome and ChatGPT Atlas page visibility
- link the new checklist from both Lab 3 README files

## Safety scope
- no prompt payloads, bypass steps, exploit code, or real payment-site testing
- synthetic lab guidance only; real payment sites, accounts, stored cards, passwords, and non-consenting users are explicitly out of scope

## Verification
- git diff --check HEAD~1..HEAD
- markdown smoke check for linked document and safety scope text