### PR TITLE
chore(deploy): auto-regenerate lab-labels.sh; add GHA drift check and pre-commit hook

### DIFF
--- a/.github/workflows/deploy_labs.yml
+++ b/.github/workflows/deploy_labs.yml
@@ -1047,6 +1047,22 @@ jobs:
           done
           echo "✅ C2 GCS buckets ready"
 
+      - name: Validate lab-labels.sh is in sync with docker-compose.yml
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.6/yq_linux_amd64
+          echo "0c2b24e645b57d8e7c0566d18643a6d4f5580feeea3878127354a46f2a1e4598  /usr/local/bin/yq" | sha256sum -c
+          sudo chmod +x /usr/local/bin/yq
+          cp deploy/traefik/lab-labels.sh /tmp/lab-labels-committed.sh
+          ./deploy/traefik/generate-lab-labels.sh
+          if ! diff -q /tmp/lab-labels-committed.sh deploy/traefik/lab-labels.sh > /dev/null; then
+            echo "❌ deploy/traefik/lab-labels.sh is out of sync with docker-compose.yml"
+            echo "   Run: ./deploy/traefik/generate-lab-labels.sh"
+            echo "   Then commit the updated lab-labels.sh alongside your docker-compose.yml changes"
+            diff /tmp/lab-labels-committed.sh deploy/traefik/lab-labels.sh || true
+            exit 1
+          fi
+          echo "✅ lab-labels.sh is in sync with docker-compose.yml"
+
       - name: Deploy shared-c2 to Cloud Run
         if: env.LABS_GCP_SA_KEY != '' && env.LABS_GCP_SA_KEY != null
         run: |
@@ -1216,6 +1232,19 @@ jobs:
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.6/yq_linux_amd64
           echo "0c2b24e645b57d8e7c0566d18643a6d4f5580feeea3878127354a46f2a1e4598  /usr/local/bin/yq" | sha256sum -c
           sudo chmod +x /usr/local/bin/yq
+
+      - name: Validate lab-labels.sh is in sync with docker-compose.yml
+        run: |
+          cp deploy/traefik/lab-labels.sh /tmp/lab-labels-committed.sh
+          ./deploy/traefik/generate-lab-labels.sh
+          if ! diff -q /tmp/lab-labels-committed.sh deploy/traefik/lab-labels.sh > /dev/null; then
+            echo "❌ deploy/traefik/lab-labels.sh is out of sync with docker-compose.yml"
+            echo "   Run: ./deploy/traefik/generate-lab-labels.sh"
+            echo "   Then commit the updated lab-labels.sh alongside your docker-compose.yml changes"
+            diff /tmp/lab-labels-committed.sh deploy/traefik/lab-labels.sh || true
+            exit 1
+          fi
+          echo "✅ lab-labels.sh is in sync with docker-compose.yml"
 
       - name: Deploy to Cloud Run
         if: env.LABS_GCP_SA_KEY != '' && env.LABS_GCP_SA_KEY != null

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,4 +61,9 @@ repos:
         files: \.go$
         args: [./...]
 
-
+      - id: generate-lab-labels
+        name: Regenerate lab-labels.sh from docker-compose.yml
+        entry: ./deploy/traefik/generate-lab-labels.sh
+        language: system
+        files: ^docker-compose\.yml$
+        pass_filenames: false

--- a/deploy/DEPLOY_SCRIPTS.md
+++ b/deploy/DEPLOY_SCRIPTS.md
@@ -2,6 +2,29 @@
 
 This document describes all deployment scripts and their usage.
 
+## Build and Deploy Flow
+
+CI/CD deployments are driven by **GitHub Actions**, not by docker-compose.
+
+```
+GHA (.github/workflows/deploy_labs.yml)
+  └─ calls deploy/deploy-labs.sh stg|prd [lab-number|all]
+       └─ for each lab:
+            1. docker build  (using the lab's Dockerfile)
+            2. docker push   (to GCP Artifact Registry: us-central1-docker.pkg.dev/labs-{env}/e-skimming-labs/)
+            3. gcloud run deploy  (all service config hardcoded per lab in deploy_labNN() functions)
+```
+
+**docker-compose.yml** is for **local development only**. It starts all services in Docker on your machine and is never used by GHA or Cloud Run.
+
+**`x-cloudrun:` stanzas** in docker-compose.yml are inert Docker Compose extension fields (the `x-` prefix means Docker Compose ignores them). They document what the Cloud Run equivalent of each service looks like, but no script currently reads them. Issue [#259](https://github.com/pci-tamper-protect/e-skimming-labs/issues/259) tracks making `deploy-labs.sh` actually parse them so adding a new lab only requires a docker-compose entry.
+
+**`deploy/traefik/lab-labels.sh`** is the bridge between local Traefik config (docker-compose labels) and Cloud Run labels. It is used by `deploy-labs.sh` to pass Traefik routing labels to `gcloud run deploy`. Its header says "AUTO-GENERATED" but it is currently maintained by hand — see issue #259.
+
+### Adding a new lab (current state)
+
+Requires changes to 8 files — see [issue #259](https://github.com/pci-tamper-protect/e-skimming-labs/issues/259) for the plan to reduce this to 2.
+
 ## Quick Reference
 
 | Script | Purpose | Example |

--- a/deploy/deploy-all.sh
+++ b/deploy/deploy-all.sh
@@ -17,8 +17,8 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Lab Traefik labels are generated from docker-compose.yml (single source of truth).
-# Re-run deploy/traefik/generate-lab-labels.sh to regenerate after docker-compose changes.
+# Regenerate Cloud Run labels from docker-compose.yml (single source of truth).
+"$SCRIPT_DIR/traefik/generate-lab-labels.sh"
 source "$SCRIPT_DIR/traefik/lab-labels.sh"
 
 source "$SCRIPT_DIR/check-credentials.sh"

--- a/deploy/deploy-labs.sh
+++ b/deploy/deploy-labs.sh
@@ -78,7 +78,8 @@ echo ""
 
 cd "$REPO_ROOT"
 
-# Source generated Cloud Run labels (from docker-compose.yml)
+# Regenerate and source Cloud Run labels (from docker-compose.yml)
+"$SCRIPT_DIR/traefik/generate-lab-labels.sh"
 source "$SCRIPT_DIR/traefik/lab-labels.sh"
 
 # Authenticate to Artifact Registry


### PR DESCRIPTION
## Summary

- `deploy-all.sh` and `deploy-labs.sh` now call `generate-lab-labels.sh` before sourcing `lab-labels.sh` — local deploys never use a stale file
- GHA: adds a **"Validate lab-labels.sh in sync"** step in both `deploy-labs-components` and `deploy-labs` jobs — installs yq, regenerates from docker-compose.yml, diffs against committed file, fails with clear fix instructions if drift is detected
- pre-commit: adds `generate-lab-labels` hook triggered on `docker-compose.yml` changes so the generated file is always re-staged automatically
- `DEPLOY_SCRIPTS.md`: documents the actual `GHA → deploy-labs.sh → gcloud` flow, clarifies docker-compose.yml is local-dev only, explains `x-cloudrun:` stanzas are inert documentation (tracked in #259)

## Context

`generate-lab-labels.sh` already existed and worked correctly — it just was never called automatically. `lab-labels.sh` claimed to be "AUTO-GENERATED" in its header but was manually maintained. This PR closes that gap without changing any routing logic.

Closes part of #259.

## Test plan

- [ ] Run `./deploy/traefik/generate-lab-labels.sh` locally — output matches committed `lab-labels.sh` (no diff)
- [ ] Modify a label in `docker-compose.yml`, run `./deploy/deploy-labs.sh stg 01 --dry-run` — verify generator runs and `lab-labels.sh` updates
- [ ] Modify `docker-compose.yml` without running generator, push to branch — GHA drift-check step should fail with diff output
- [ ] Modify `docker-compose.yml` with pre-commit installed — `lab-labels.sh` is auto-regenerated and re-staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)